### PR TITLE
feat: upgrade to .NET 9 and add ShareX settings panel

### DIFF
--- a/Flow.Launcher.Plugin.ShareX-Flow-Plugin.csproj
+++ b/Flow.Launcher.Plugin.ShareX-Flow-Plugin.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <AssemblyName>Flow.Launcher.Plugin.ShareX_Flow_Plugin</AssemblyName>
     <PackageId>Flow.Launcher.Plugin.ShareX_Flow_Plugin</PackageId>
     <Authors>Dufguix</Authors>

--- a/Flow.Launcher.Plugin.ShareX-Flow-Plugin.csproj
+++ b/Flow.Launcher.Plugin.ShareX-Flow-Plugin.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <AssemblyName>Flow.Launcher.Plugin.ShareX_Flow_Plugin</AssemblyName>
+    <RootNamespace>Flow.Launcher.Plugin.ShareX_Flow_Plugin</RootNamespace>
     <PackageId>Flow.Launcher.Plugin.ShareX_Flow_Plugin</PackageId>
     <Authors>Dufguix</Authors>
     <PackageProjectUrl>https://github.com/Dufguix/Flow.Launcher.Plugin.ShareX_Flow_Plugin</PackageProjectUrl>

--- a/Main.cs
+++ b/Main.cs
@@ -3,85 +3,87 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Windows.Controls;
 
 namespace Flow.Launcher.Plugin.ShareX_Flow_Plugin
 {
-    public class ShareX_Flow_Plugin : IPlugin
+    public class ShareX_Flow_Plugin : IPlugin, ISettingProvider
     {
         private PluginInitContext _context;
-        private String _sharexExe;
-        private String _sharexPath;
+        private string _sharexExe;
+        private Settings _settings;
+        private SettingsViewModel _viewModel;
         private List<SharexCommand> _sharexCommands;
 
         public void Init(PluginInitContext context)
         {
             _context = context;
+            _settings = context.API.LoadSettingJsonStorage<Settings>();
+            _viewModel = new SettingsViewModel(_settings);
             _sharexExe = "ShareX.exe";
-            _sharexPath = "C:\\Program Files\\ShareX\\";
-            _sharexCommands = new List<SharexCommand>
-            {
-                new SharexCommand {Title = "FileUpload", SubTitle="Upload file", Command="-FileUpload", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "FolderUpload", SubTitle="Upload folder", Command="-FolderUpload", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "ClipboardUpload", SubTitle="Upload from clipboard", Command="-ClipboardUpload", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "ClipboardUploadWithContentViewer", SubTitle="Upload from clipboard with content viewer", Command="-ClipboardUploadWithContentViewer", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "UploadText", SubTitle="Upload text", Command="-UploadText", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "UploadURL", SubTitle="Upload from URL", Command="-UploadURL", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "DragDropUpload", SubTitle="Drag and drop upload", Command="-DragDropUpload", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "ShortenURL", SubTitle="Shorten URL", Command="-ShortenURL", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "TweetMessage", SubTitle="Tweet message", Command="-TweetMessage", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "StopUploads", SubTitle="Stop all active uploads", Command="-StopUploads", Category=SharexCommand.Cat.Upload, IcoPath=""},
-                new SharexCommand {Title = "PrintScreen", SubTitle="Capture entire screen", Command="-PrintScreen", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "ActiveWindow", SubTitle="Capture active window", Command="-ActiveWindow", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "ActiveMonitor", SubTitle="Capture active monitor", Command="-ActiveMonitor", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "RectangleRegion", SubTitle="Capture region", Command="-RectangleRegion", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "RectangleLight", SubTitle="Capture region (Light)", Command="-RectangleLight", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "RectangleTransparent", SubTitle="Capture region (Transparent)", Command="-RectangleTransparent", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "CustomRegion", SubTitle="Capture pre configured region", Command="-CustomRegion", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "LastRegion", SubTitle="Capture last region", Command="-LastRegion", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "ScrollingCapture", SubTitle="Scrolling capture", Command="-ScrollingCapture", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "AutoCapture", SubTitle="Auto capture", Command="-AutoCapture", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "StartAutoCapture", SubTitle="Start auto capture using last region", Command="-StartAutoCapture", Category=SharexCommand.Cat.ScreenCapture, IcoPath=""},
-                new SharexCommand {Title = "ScreenRecorder", SubTitle="Start/Stop screen recording", Command="-ScreenRecorder", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "ScreenRecorderActiveWindow", SubTitle="Start/Stop screen recording using active window region", Command="-ScreenRecorderActiveWindow", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "ScreenRecorderCustomRegion", SubTitle="Start/Stop screen recording using pre configured region", Command="-ScreenRecorderCustomRegion", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "StartScreenRecorder", SubTitle="Start/Stop screen recording using last region", Command="-StartScreenRecorder", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "ScreenRecorderGIF", SubTitle="Start/Stop screen recording (GIF)", Command="-ScreenRecorderGIF", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "ScreenRecorderGIFActiveWindow", SubTitle="Start/Stop screen recording (GIF) using active window region", Command="-ScreenRecorderGIFActiveWindow", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "ScreenRecorderGIFCustomRegion", SubTitle="Start/Stop screen recording (GIF) using pre configured region", Command="-ScreenRecorderGIFCustomRegion", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "StartScreenRecorderGIF", SubTitle="Start/Stop screen recording (GIF) using last region", Command="-StartScreenRecorderGIF", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "StopScreenRecording", SubTitle="Stop screen recording", Command="-StopScreenRecording", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "AbortScreenRecording", SubTitle="Abort screen recording", Command="-AbortScreenRecording", Category=SharexCommand.Cat.ScreenRecord, IcoPath=""},
-                new SharexCommand {Title = "ColorPicker", SubTitle="Color picker", Command="-ColorPicker", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "ScreenColorPicker", SubTitle="Screen color picker", Command="-ScreenColorPicker", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "Ruler", SubTitle="Ruler", Command="-Ruler", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "ImageEditor", SubTitle="Image editor", Command="-ImageEditor", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "ImageEffects", SubTitle="Image effects", Command="-ImageEffects", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "ImageViewer", SubTitle="", Command="-ImageViewer", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "ImageCombiner", SubTitle="Image combiner", Command="-ImageCombiner", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "ImageSplitter", SubTitle="Image splitter", Command="-ImageSplitter", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "ImageThumbnailer", SubTitle="Image thumbnailer", Command="-ImageThumbnailer", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "VideoConverter", SubTitle="Video converter", Command="-VideoConverter", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "VideoThumbnailer", SubTitle="Video thumbnailer", Command="-VideoThumbnailer", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "OCR", SubTitle="Text capture (OCR)", Command="-OCR", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "QRCode", SubTitle="QR code", Command="-QRCode", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "QRCodeDecodeFromScreen", SubTitle="QR code (Decode from screen)", Command="-QRCodeDecodeFromScreen", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "HashCheck", SubTitle="Hash check", Command="-HashCheck", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "IndexFolder", SubTitle="Index folder", Command="-IndexFolder", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "ClipboardViewer", SubTitle="Clipboard viewer", Command="-ClipboardViewer", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "BorderlessWindow", SubTitle="", Command="-BorderlessWindow", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "InspectWindow", SubTitle="Inspect window", Command="-InspectWindow", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "MonitorTest", SubTitle="Monitor test", Command="-MonitorTest", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "DNSChanger", SubTitle="DNS changer", Command="-DNSChanger", Category=SharexCommand.Cat.Tools, IcoPath=""},
-                new SharexCommand {Title = "DisableHotkeys", SubTitle="Disable/Enable hotkeys", Command="-DisableHotkeys", Category=SharexCommand.Cat.Other, IcoPath=""},
-                new SharexCommand {Title = "OpenMainWindow", SubTitle="Open main window", Command="-OpenMainWindow", Category=SharexCommand.Cat.Other, IcoPath=""},
-                new SharexCommand {Title = "OpenScreenshotsFolder", SubTitle="Open screenshots folder", Command="-OpenScreenshotsFolder", Category=SharexCommand.Cat.Other, IcoPath=""},
-                new SharexCommand {Title = "OpenHistory", SubTitle="Open history window", Command="-OpenHistory", Category=SharexCommand.Cat.Other, IcoPath=""},
-                new SharexCommand {Title = "OpenImageHistory", SubTitle="Open image history window", Command="-OpenImageHistory", Category=SharexCommand.Cat.Other, IcoPath=""},
-                new SharexCommand {Title = "ToggleActionsToolbar", SubTitle="Toggle actions toolbar", Command="-ToggleActionsToolbar", Category=SharexCommand.Cat.Other, IcoPath=""},
-                new SharexCommand {Title = "ToggleTrayMenu", SubTitle="Toggle tray menu", Command="-ToggleTrayMenu", Category=SharexCommand.Cat.Other, IcoPath=""},
-                new SharexCommand {Title = "ExitShareX", SubTitle="Exit ShareX", Command="-ExitShareX", Category=SharexCommand.Cat.Other, IcoPath=""}
-            };
-
+            _sharexCommands =
+            [
+                new() {Title = "FileUpload", SubTitle="Upload file", Command="-FileUpload", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "FolderUpload", SubTitle="Upload folder", Command="-FolderUpload", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "ClipboardUpload", SubTitle="Upload from clipboard", Command="-ClipboardUpload", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "ClipboardUploadWithContentViewer", SubTitle="Upload from clipboard with content viewer", Command="-ClipboardUploadWithContentViewer", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "UploadText", SubTitle="Upload text", Command="-UploadText", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "UploadURL", SubTitle="Upload from URL", Command="-UploadURL", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "DragDropUpload", SubTitle="Drag and drop upload", Command="-DragDropUpload", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "ShortenURL", SubTitle="Shorten URL", Command="-ShortenURL", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "TweetMessage", SubTitle="Tweet message", Command="-TweetMessage", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "StopUploads", SubTitle="Stop all active uploads", Command="-StopUploads", Category=SharexCommand.CategoryType.Upload, IcoPath=""},
+                new() {Title = "PrintScreen", SubTitle="Capture entire screen", Command="-PrintScreen", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "ActiveWindow", SubTitle="Capture active window", Command="-ActiveWindow", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "ActiveMonitor", SubTitle="Capture active monitor", Command="-ActiveMonitor", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "RectangleRegion", SubTitle="Capture region", Command="-RectangleRegion", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "RectangleLight", SubTitle="Capture region (Light)", Command="-RectangleLight", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "RectangleTransparent", SubTitle="Capture region (Transparent)", Command="-RectangleTransparent", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "CustomRegion", SubTitle="Capture pre configured region", Command="-CustomRegion", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "LastRegion", SubTitle="Capture last region", Command="-LastRegion", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "ScrollingCapture", SubTitle="Scrolling capture", Command="-ScrollingCapture", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "AutoCapture", SubTitle="Auto capture", Command="-AutoCapture", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "StartAutoCapture", SubTitle="Start auto capture using last region", Command="-StartAutoCapture", Category=SharexCommand.CategoryType.ScreenCapture, IcoPath=""},
+                new() {Title = "ScreenRecorder", SubTitle="Start/Stop screen recording", Command="-ScreenRecorder", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "ScreenRecorderActiveWindow", SubTitle="Start/Stop screen recording using active window region", Command="-ScreenRecorderActiveWindow", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "ScreenRecorderCustomRegion", SubTitle="Start/Stop screen recording using pre configured region", Command="-ScreenRecorderCustomRegion", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "StartScreenRecorder", SubTitle="Start/Stop screen recording using last region", Command="-StartScreenRecorder", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "ScreenRecorderGIF", SubTitle="Start/Stop screen recording (GIF)", Command="-ScreenRecorderGIF", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "ScreenRecorderGIFActiveWindow", SubTitle="Start/Stop screen recording (GIF) using active window region", Command="-ScreenRecorderGIFActiveWindow", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "ScreenRecorderGIFCustomRegion", SubTitle="Start/Stop screen recording (GIF) using pre configured region", Command="-ScreenRecorderGIFCustomRegion", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "StartScreenRecorderGIF", SubTitle="Start/Stop screen recording (GIF) using last region", Command="-StartScreenRecorderGIF", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "StopScreenRecording", SubTitle="Stop screen recording", Command="-StopScreenRecording", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "AbortScreenRecording", SubTitle="Abort screen recording", Command="-AbortScreenRecording", Category=SharexCommand.CategoryType.ScreenRecord, IcoPath=""},
+                new() {Title = "ColorPicker", SubTitle="Color picker", Command="-ColorPicker", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "ScreenColorPicker", SubTitle="Screen color picker", Command="-ScreenColorPicker", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "Ruler", SubTitle="Ruler", Command="-Ruler", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "ImageEditor", SubTitle="Image editor", Command="-ImageEditor", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "ImageEffects", SubTitle="Image effects", Command="-ImageEffects", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "ImageViewer", SubTitle="", Command="-ImageViewer", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "ImageCombiner", SubTitle="Image combiner", Command="-ImageCombiner", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "ImageSplitter", SubTitle="Image splitter", Command="-ImageSplitter", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "ImageThumbnailer", SubTitle="Image thumbnailer", Command="-ImageThumbnailer", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "VideoConverter", SubTitle="Video converter", Command="-VideoConverter", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "VideoThumbnailer", SubTitle="Video thumbnailer", Command="-VideoThumbnailer", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "OCR", SubTitle="Text capture (OCR)", Command="-OCR", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "QRCode", SubTitle="QR code", Command="-QRCode", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "QRCodeDecodeFromScreen", SubTitle="QR code (Decode from screen)", Command="-QRCodeDecodeFromScreen", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "HashCheck", SubTitle="Hash check", Command="-HashCheck", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "IndexFolder", SubTitle="Index folder", Command="-IndexFolder", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "ClipboardViewer", SubTitle="Clipboard viewer", Command="-ClipboardViewer", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "BorderlessWindow", SubTitle="", Command="-BorderlessWindow", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "InspectWindow", SubTitle="Inspect window", Command="-InspectWindow", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "MonitorTest", SubTitle="Monitor test", Command="-MonitorTest", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "DNSChanger", SubTitle="DNS changer", Command="-DNSChanger", Category=SharexCommand.CategoryType.Tools, IcoPath=""},
+                new() {Title = "DisableHotkeys", SubTitle="Disable/Enable hotkeys", Command="-DisableHotkeys", Category=SharexCommand.CategoryType.Other, IcoPath=""},
+                new() {Title = "OpenMainWindow", SubTitle="Open main window", Command="-OpenMainWindow", Category=SharexCommand.CategoryType.Other, IcoPath=""},
+                new() {Title = "OpenScreenshotsFolder", SubTitle="Open screenshots folder", Command="-OpenScreenshotsFolder", Category=SharexCommand.CategoryType.Other, IcoPath=""},
+                new() {Title = "OpenHistory", SubTitle="Open history window", Command="-OpenHistory", Category=SharexCommand.CategoryType.Other, IcoPath=""},
+                new() {Title = "OpenImageHistory", SubTitle="Open image history window", Command="-OpenImageHistory", Category=SharexCommand.CategoryType.Other, IcoPath=""},
+                new() {Title = "ToggleActionsToolbar", SubTitle="Toggle actions toolbar", Command="-ToggleActionsToolbar", Category=SharexCommand.CategoryType.Other, IcoPath=""},
+                new() {Title = "ToggleTrayMenu", SubTitle="Toggle tray menu", Command="-ToggleTrayMenu", Category=SharexCommand.CategoryType.Other, IcoPath=""},
+                new() {Title = "ExitShareX", SubTitle="Exit ShareX", Command="-ExitShareX", Category=SharexCommand.CategoryType.Other, IcoPath=""}
+            ];
         }
 
         public List<Result> Query(Query query)
@@ -101,14 +103,25 @@ namespace Flow.Launcher.Plugin.ShareX_Flow_Plugin
             return results;
         }
 
-        private bool RunCommand(ActionContext e, String cmd)
+        public Control CreateSettingPanel()
         {
-            //_context.API.ShowMsg("Start ShareX : " + cmd);
+            return new SettingsView(_viewModel);
+        }
+
+        private bool RunCommand(ActionContext _, string cmd)
+        {
             try
             {
-                var startInfo = new ProcessStartInfo(_sharexExe, cmd);
-                startInfo.UseShellExecute = true;
-                startInfo.WorkingDirectory = _sharexPath;
+                var extraArgs = " -silent";
+                if (_settings.AutoClose)
+                {
+                    extraArgs += " -autoclose";
+                }
+                var startInfo = new ProcessStartInfo(_sharexExe, cmd + extraArgs)
+                {
+                    UseShellExecute = true,
+                    WorkingDirectory = _settings.SharexPath
+                };
                 Process.Start(startInfo);
             }
             catch (Win32Exception w32Ex)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 ﻿# ShareX Plugin for Flow Launcher
 
-## Plugin working
-All commands are based on ShareX HotkeyType Enum found on their [Github](https://github.com/ShareX/ShareX/blob/master/ShareX/Enums.cs).
+## Plugin behavior
+All commands are based on ShareX HotkeyType enum from [ShareX/Enums.cs](https://github.com/ShareX/ShareX/blob/master/ShareX/Enums.cs).
 
-There is currently no setting panel. It is based on **default** [ShareX](https://getsharex.com/downloads) installation path.
+The plugin now includes a settings panel in Flow Launcher:
+- Configure ShareX installation path (defaults to `C:\Program Files\ShareX\`).
+- Enable/disable auto close (`-autoclose`) after successful tasks.
+
+When executing commands, the plugin starts ShareX with `-silent` and optionally `-autoclose`.
 
 ## Manual installation
-1) Open the solution with Visual Studio 2022.
-2) Run a release build.
-3) Copy the content of the ".\bin\Release\" folder.
-4) Paste to "C:\Users\username\AppData\Roaming\FlowLauncher\Plugins\ShareX" folder.
+1. Open the solution with Visual Studio 2026.
+2. Build in Release.
+3. Copy the content of `.\bin\Release\`.
+4. Paste into `C:\Users\<username>\AppData\Roaming\FlowLauncher\Plugins\ShareX`.

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,0 +1,8 @@
+namespace Flow.Launcher.Plugin.ShareX_Flow_Plugin
+{
+    public class Settings
+    {
+        public string SharexPath { get; set; } = "C:\\Program Files\\ShareX\\";
+        public bool AutoClose { get; set; } = false;
+    }
+}

--- a/SettingsView.xaml
+++ b/SettingsView.xaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="Flow.Launcher.Plugin.ShareX_Flow_Plugin.SettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Flow.Launcher.Plugin.ShareX_Flow_Plugin"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance local:SettingsViewModel}"
+             d:DesignHeight="450"
+			 d:DesignWidth="800">
+
+
+
+	<StackPanel Margin="{DynamicResource SettingPanelMargin}" >
+		<Grid Margin="{DynamicResource SettingPanelItemTopBottomMargin}">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto"/>
+				<ColumnDefinition Width="Auto"/>
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+			<TextBlock Grid.Column="0" VerticalAlignment="Center" Text="ShareX installation path:" Margin="{DynamicResource SettingPanelItemRightMargin}" />
+			<TextBox Grid.Column="1" Text="{Binding SharexPath, Mode=TwoWay}" IsReadOnly="False" Margin="{DynamicResource SettingPanelItemRightMargin}"/>
+            <Button Grid.Column="2" HorizontalAlignment="Center" Content="{DynamicResource flowlauncher_plugin_url_plugin_choose}" Click="BrowseSharexPath" />
+		</Grid>
+
+		<CheckBox
+			Margin="{DynamicResource SettingPanelItemTopBottomMargin}"
+			HorizontalAlignment="Left"
+			VerticalAlignment="Center"
+			Content="Close ShareX after successfully completing some tasks"
+			IsChecked="{Binding AutoClose, Mode=TwoWay}" />
+	</StackPanel>
+</UserControl>

--- a/SettingsView.xaml
+++ b/SettingsView.xaml
@@ -5,7 +5,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Flow.Launcher.Plugin.ShareX_Flow_Plugin"
              mc:Ignorable="d" 
-             d:DataContext="{d:DesignInstance local:SettingsViewModel}"
              d:DesignHeight="450"
 			 d:DesignWidth="800">
 

--- a/SettingsView.xaml.cs
+++ b/SettingsView.xaml.cs
@@ -1,0 +1,31 @@
+using System.Windows.Controls;
+using System.Windows;
+
+namespace Flow.Launcher.Plugin.ShareX_Flow_Plugin
+{
+    public partial class SettingsView : UserControl
+    {
+        private readonly SettingsViewModel _viewModel;
+
+        public SettingsView(SettingsViewModel viewModel)
+        {
+            _viewModel = viewModel;
+            DataContext = _viewModel;
+            InitializeComponent();
+        }
+
+        private void BrowseSharexPath(object sender, RoutedEventArgs e)
+        {
+            var dialog = new Microsoft.Win32.OpenFolderDialog
+            {
+                InitialDirectory = _viewModel.SharexPath,
+                Title = "Select ShareX Installation Folder"
+            };
+
+            if (dialog.ShowDialog() == true)
+            {
+                _viewModel.SharexPath = dialog.FolderName;
+            }
+        }
+    }
+}

--- a/SettingsViewModel.cs
+++ b/SettingsViewModel.cs
@@ -1,0 +1,33 @@
+namespace Flow.Launcher.Plugin.ShareX_Flow_Plugin
+{
+    public class SettingsViewModel(Settings settings) : BaseModel
+    {
+        private readonly Settings Settings = settings;
+
+        public string SharexPath
+        {
+            get => Settings.SharexPath;
+            set
+            {
+                if (Settings.SharexPath != value)
+                {
+                    Settings.SharexPath = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool AutoClose
+        {
+            get => Settings.AutoClose;
+            set
+            {
+                if (Settings.AutoClose != value)
+                {
+                    Settings.AutoClose = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+    }
+}

--- a/SettingsViewModel.cs
+++ b/SettingsViewModel.cs
@@ -2,16 +2,16 @@ namespace Flow.Launcher.Plugin.ShareX_Flow_Plugin
 {
     public class SettingsViewModel(Settings settings) : BaseModel
     {
-        private readonly Settings Settings = settings;
+        private readonly Settings _settings = settings;
 
         public string SharexPath
         {
-            get => Settings.SharexPath;
+            get => _settings.SharexPath;
             set
             {
-                if (Settings.SharexPath != value)
+                if (_settings.SharexPath != value)
                 {
-                    Settings.SharexPath = value;
+                    _settings.SharexPath = value;
                     OnPropertyChanged();
                 }
             }
@@ -19,12 +19,12 @@ namespace Flow.Launcher.Plugin.ShareX_Flow_Plugin
 
         public bool AutoClose
         {
-            get => Settings.AutoClose;
+            get => _settings.AutoClose;
             set
             {
-                if (Settings.AutoClose != value)
+                if (_settings.AutoClose != value)
                 {
-                    Settings.AutoClose = value;
+                    _settings.AutoClose = value;
                     OnPropertyChanged();
                 }
             }

--- a/SharexCommand.cs
+++ b/SharexCommand.cs
@@ -6,23 +6,14 @@ using System.Threading.Tasks;
 
 namespace Flow.Launcher.Plugin.ShareX_Flow_Plugin
 {
-    class SharexCommand
+    public record SharexCommand
     {
-        public enum Cat {Upload, ScreenCapture, ScreenRecord, Tools, Other};
+        public enum CategoryType { Upload, ScreenCapture, ScreenRecord, Tools, Other };
 
-        public String Title
-        { get; set; }
-
-        public String SubTitle
-        { get; set; }
-
-        public String Command
-        { get; set; }
-
-        public Cat Category
-        { get; set; }
-
-        public String IcoPath
-        { get; set; }
+        public string Title { get; init; }
+        public string SubTitle { get; init; }
+        public string Command { get; init; }
+        public CategoryType Category { get; init; }
+        public string IcoPath { get; init; }
     }
 }

--- a/packages.lock.json
+++ b/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net5.0-windows7.0": {
+    "net9.0-windows7.0": {
       "Flow.Launcher.Plugin": {
         "type": "Direct",
         "requested": "[2.1.1, )",

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "ShareX_Flow_Plugin",
   "Description": "Run ShareX capture, OCR, ...",
   "Author": "Dufguix",
-  "Version": "1.0.0",
+  "Version": "1.1.0",
   "Language": "csharp",
   "Website": "https://github.com/dufguix/Flow.Launcher.Plugin.ShareX",
   "IcoPath": "icon.png",


### PR DESCRIPTION
## Overview
This PR modernizes the ShareX Flow Launcher plugin by upgrading the target framework to .NET 9 and introducing a user-configurable settings panel.

## Changes

### 1. **chore: upgrade plugin target to net9 and update lockfile** (47a72a2)
   - Upgrades `TargetFramework` from `net5.0-windows` to `net9.0-windows`
   - Adds `<UseWPF>true</UseWPF>` for explicit WPF support
   - Updates `packages.lock.json` to reflect new framework

### 2. **feat: add ShareX settings panel and configurable launch options** (02693c3)
   - Implements `ISettingProvider` in `ShareX_Flow_Plugin` class
   - Adds `CreateSettingPanel()` method exposing settings UI
   - New `Settings` class with configurable properties:
     - `SharexPath`: Installation path (default: `C:\Program Files\ShareX\`)
     - `AutoClose`: Boolean flag for `-autoclose` behavior
   - New `SettingsViewModel` class for WPF binding and change notifications
   - New `SettingsView.xaml` / `xaml.cs` for UI layout and folder browser dialog
   - Refactors `SharexCommand` to an immutable `record` with `init`-only properties
   - Renames `Cat` enum to `CategoryType` for clarity
   - `RunCommand()` now:
     - Always appends `-silent` flag
     - Conditionally appends `-autoclose` based on settings
     - Uses persisted `Settings.SharexPath` instead of hardcoded path

### 3. **docs: refresh README for settings panel and launch args** (34422bf)
   - Removes outdated note about missing settings panel
   - Documents new settings behavior and configuration options
   - Updates installation steps for clarity

## Testing
- Solution builds successfully against .NET 9
- Settings panel appears in Flow Launcher plugin settings
- ShareX launch args include `-silent` and optional `-autoclose`

## Commits
- 3 focused, logical commits for clean history
- Clean working tree (only `.editorconfig` untracked, left for local use)